### PR TITLE
Fix area grub miscounting when breaking a grub jar placed by rando

### DIFF
--- a/BingoUI/BingoUI.cs
+++ b/BingoUI/BingoUI.cs
@@ -103,7 +103,7 @@ namespace BingoUI
 
             Log("Creating Canvases");
 
-            Dictionary<string, Sprite> sprites = SeanprCore.ResourceHelper.GetSprites();
+            Dictionary<string, Sprite> sprites = SereCore.ResourceHelper.GetSprites();
             // Define anchor minimum and maximum so we can modify them in a loop and display the images systematically
             Vector2 anchorMin = new Vector2(0f, 0.01f);
             Vector2 anchorMax = new Vector2(1f/15f, 0.1f);
@@ -192,6 +192,26 @@ namespace BingoUI
             UnityEngine.Object.Destroy(_coroutineStarter.gameObject);
         }
 
+        private static bool GrubsRandomized() {
+            var rando = Type.GetType("RandomizerMod.RandomizerMod, RandomizerMod3.0");
+            if (rando == null) {
+                return false;
+            }
+            var settingsType = Type.GetType("RandomizerMod.SaveSettings, RandomizerMod3.0");
+            if (settingsType == null) {
+                return false;
+            }
+            var randoInstance = rando.GetProperty("Instance", BindingFlags.Public | BindingFlags.Static).GetValue(null, null);
+            if (randoInstance == null) {
+                return false;
+            }
+            var settings = rando.GetProperty("Settings").GetValue(randoInstance, null);
+            if (settings == null) {
+                return false;
+            }
+            return (bool)settingsType.GetProperty("RandomizeGrubs").GetValue(settings, null);
+        }
+
         /**
          * Check if the Int that changed is something to track, and if so display the canvas and the updated number
          */
@@ -226,7 +246,7 @@ namespace BingoUI
                 // grubs
                 case nameof(pd.grubsCollected):
                 
-                    UpdateGrubs();
+                    UpdateGrubs(!GrubsRandomized());
                     break;
 
                 case nameof(pd.nailSmithUpgrades): // Update on upgrades, else it shows as if we "lost" ore
@@ -618,10 +638,10 @@ namespace BingoUI
             return false;
         }
         
-        private static void DummyRandoAreaGrubSet(string location)
+        private void DummyRandoAreaGrubSet(string location)
         {
             // Increments area grubs. Hooked to checking a grub location in rando, dead otherwise
-            PlayerData.instance.SetInt(nameof(PlayerData.instance.grubsCollected), PlayerData.instance.grubsCollected);
+            UpdateGrubs(true);
         }
 
         #endregion

--- a/BingoUI/BingoUI.csproj
+++ b/BingoUI/BingoUI.csproj
@@ -74,8 +74,8 @@
     <Reference Include="RandomizerMod3.0, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>Assembly References\RandomizerMod3.0.dll</HintPath>
     </Reference>
-    <Reference Include="SeanprCore, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>Assembly References\SeanprCore.dll</HintPath>
+    <Reference Include="SereCore, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>Assembly References\SereCore.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>Assembly References\UnityEngine.dll</HintPath>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A tool that displays progress towards some of the most common counting bingo goals on screen every time progress is made towards one of them.
 
-Requires modding API version -56 or higher and SeanprCore.
+Requires modding API version -56 or higher and SereCore.
 
 Also has a global setting for always displaying the icons
 


### PR DESCRIPTION
This mod assumed - until recently, correctly - that if the player
broke a grub jar, that grub jar was at a vanilla location. With
grub jar rando - which will be on the mod installer soon(tm) -
this is no longer the case.

This patch does not affect the behavior when using previous versions
of rando.